### PR TITLE
Ed kit event data

### DIFF
--- a/source/client.vcxproj
+++ b/source/client.vcxproj
@@ -47,6 +47,8 @@
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionName)_$(ProjectName)_$(Configuration)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionName)_$(ProjectName)_$(Configuration)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/source/client.vcxproj
+++ b/source/client.vcxproj
@@ -37,10 +37,10 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -62,7 +62,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalOptions>$(SolutionPath)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>$(SolutionDir)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)$(SolutionName)_$(ProjectName)_$(Configuration).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>false</GenerateMapFile>
@@ -91,7 +91,7 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalOptions>$(SolutionPath)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>$(SolutionDir)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)$(SolutionName)_$(ProjectName)_$(Configuration).exe</OutputFile>
       <SubSystem>Console</SubSystem>
       <LargeAddressAware>false</LargeAddressAware>

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -11,8 +11,7 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   ed::event_source es;
   es.event = TEST_EVENT;
   RegisterPostHandler(&module_AAA::AllEventsListener, es);
- // SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
-//  SetPostEventHandler(&module_AAA::MyTypeExample, es);
+  RegisterPostHandler(&module_AAA::MyTypeExample, es);
 }
 
 void module_AAA::MyTypeExample( const ed::event_context<my_type> &a )

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -10,7 +10,7 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   RegisterEvent(TOSTRING(TEST_EVENT), TEST_EVENT);
   ed::event_source es;
   es.event = TEST_EVENT;
-  SysCreateHandler(&module_AAA::AllEventsListener, es);
+  RegisterPostHandler(&module_AAA::AllEventsListener, es);
  // SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
 //  SetPostEventHandler(&module_AAA::MyTypeExample, es);
 }

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -11,6 +11,7 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   ed::event_source es;
   es.event = TEST_EVENT;
   SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
+  SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::MyTypeExample), es);
 }
 
 #include <iostream>

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -10,8 +10,9 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   RegisterEvent(TOSTRING(TEST_EVENT), TEST_EVENT);
   ed::event_source es;
   es.event = TEST_EVENT;
-  SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
-  SetPostEventHandler(&module_AAA::MyTypeExample, es);
+  SysCreateHandler(&module_AAA::AllEventsListener, es);
+ // SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
+//  SetPostEventHandler(&module_AAA::MyTypeExample, es);
 }
 
 void module_AAA::MyTypeExample( const ed::event_context<my_type> &a )

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -14,6 +14,11 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   SetPostEventHandler(&module_AAA::MyTypeExample, es);
 }
 
+void module_AAA::MyTypeExample( const ed::event_context<my_type> &a )
+{
+
+}
+
 #include <iostream>
 
 void module_AAA::AllEventsListener( const ed::event_context<> &c )

--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -11,7 +11,7 @@ module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
   ed::event_source es;
   es.event = TEST_EVENT;
   SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::AllEventsListener), es);
-  SetPostEventHandler(static_cast<post_event_handler_t>(&module_AAA::MyTypeExample), es);
+  SetPostEventHandler(&module_AAA::MyTypeExample, es);
 }
 
 #include <iostream>

--- a/source/client/module_AAA.h
+++ b/source/client/module_AAA.h
@@ -3,8 +3,11 @@
 
 #include "header.h"
 
-struct my_type : public ed::event_data
+struct my_type
 {
+  my_type( const ed::event_data & )
+  {
+  }
 };
 
 class module_AAA : public ed::module

--- a/source/client/module_AAA.h
+++ b/source/client/module_AAA.h
@@ -3,9 +3,14 @@
 
 #include "header.h"
 
+struct my_type : public ed::event_data
+{
+};
+
 class module_AAA : public ed::module
 {
   void AllEventsListener( const ed::event_context<> & );
+  void MyTypeExample( const ed::event_context<my_type> & );
 public:
   module_AAA( ed::gateway &_gw );
   void SendTestEvents();

--- a/source/client/module_BBB.cpp
+++ b/source/client/module_BBB.cpp
@@ -13,7 +13,7 @@ module_BBB::module_BBB( ed::gateway &_gw ) : module("moduleBBB", _gw)
 
   ed::event_source es;
   es.event = AAA_TEST_EVENT;
-  SetPreEventHandler(static_cast<pre_event_handler_t>(&module_BBB::CheckAAAEventTEST), es);
+//  SetPreEventHandler(static_cast<pre_event_handler_t>(&module_BBB::CheckAAAEventTEST), es);
 }
 
 bool module_BBB::CheckAAAEventTEST( const ed::event_context<> & )

--- a/source/client/module_BBB.cpp
+++ b/source/client/module_BBB.cpp
@@ -13,7 +13,7 @@ module_BBB::module_BBB( ed::gateway &_gw ) : module("moduleBBB", _gw)
 
   ed::event_source es;
   es.event = AAA_TEST_EVENT;
-//  SetPreEventHandler(static_cast<pre_event_handler_t>(&module_BBB::CheckAAAEventTEST), es);
+  RegisterPreHandler(&module_BBB::CheckAAAEventTEST, es);
 }
 
 bool module_BBB::CheckAAAEventTEST( const ed::event_context<> & )

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -37,10 +37,10 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -131,6 +131,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ed\exceptions\exception.cpp" />
+    <ClCompile Include="ed\kit\event_handler_convert.cpp" />
     <ClCompile Include="ed\names\dictionary.cpp" />
     <ClCompile Include="ed\names\name_server.cpp" />
     <ClCompile Include="ed\names\translate.cpp" />

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -95,6 +95,7 @@
     <ClInclude Include="ed\exceptions\exception.h" />
     <ClInclude Include="ed\kit\event_context.h" />
     <ClInclude Include="ed\kit\event_data.h" />
+    <ClInclude Include="ed\kit\event_handler_convert.h" />
     <ClInclude Include="ed\names\dictionary.h" />
     <ClInclude Include="ed\names\name_server.h" />
     <ClInclude Include="ed\names\name_type.h" />

--- a/source/ed.vcxproj.filters
+++ b/source/ed.vcxproj.filters
@@ -139,6 +139,9 @@
     <ClInclude Include="ed\kit\event_context.h">
       <Filter>kit</Filter>
     </ClInclude>
+    <ClInclude Include="ed\kit\event_handler_convert.h">
+      <Filter>kit</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ed\exceptions\exception.cpp">

--- a/source/ed.vcxproj.filters
+++ b/source/ed.vcxproj.filters
@@ -204,5 +204,8 @@
     <ClCompile Include="ed\kit\module_callback.cpp">
       <Filter>kit</Filter>
     </ClCompile>
+    <ClCompile Include="ed\kit\event_handler_convert.cpp">
+      <Filter>kit</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/source/ed/kit/event_context.h
+++ b/source/ed/kit/event_context.h
@@ -19,6 +19,7 @@ namespace ed
     event_context( int _event_local_id, const event_source &_source, dataT *const _payload  )
       : event_local_id(_event_local_id), source(_source), payload(_payload)
     {
+      throw_assert(payload);
     }
     ~event_context()
     {
@@ -27,9 +28,21 @@ namespace ed
   };
 
   template<typename dataT>
-  struct event_context : public event_context<>
+  struct event_context
   {
+    int event_local_id;
+    const event_source source;
+    dataT *const payload;
 
+    event_context( const event_context<> a )
+      : event_local_id(a.event_local_id), source(a.source), payload(NEW dataT(*a.payload))      
+    {
+    }
+
+    ~event_context()
+    {
+      delete payload;
+    }
   };
 };
 

--- a/source/ed/kit/event_handler_convert.cpp
+++ b/source/ed/kit/event_handler_convert.cpp
@@ -1,0 +1,12 @@
+/*
+#include "module.h"
+#include "event_handler_convert.h"
+
+static childT event_handler_convert::Convert( parentT f )
+{
+  return reinterpret_cast<childT>(f);
+}
+static parentT event_handler_convert::Convert( childT f )
+{
+  return reinterpret_cast<parentT>(f);
+}             */

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -1,6 +1,8 @@
 #ifndef _ED_KIT_EVENT_HANDLER_CONVERT_H_
 #define _ED_KIT_EVENT_HANDLER_CONVERT_H_
 
+#include "event_context.h"
+
 namespace ed
 {
   template<typename T>
@@ -9,18 +11,23 @@ namespace ed
   template<typename T>
   class event_handler_convert
   {
-    typedef void event_context<T> preffered_type;
-    typedef void (*childT)( const preffered & );
+  public:
+    typedef event_context<T> prefferedT;
+    typedef void (*childT)( const prefferedT & );
     typedef void (*parentT)( const event_context<> & );
 
-    childT Convert( parentT f )
+    static childT Convert( parentT f )
     {
       return reinterpret_cast<childT>(f);
     }
-  public:
-    virtual void FarCall( parent_T _f, event_context<> &_obj )
+    static parentT Convert( parentT f )
     {
-      preffered_type obj = _obj;
+      return reinterpret_cast<parentT>(f);
+    }
+  public:
+    virtual void FarCall( parentT _f, event_context<> &_obj )
+    {
+      prefferedT obj = _obj;
       childT f = _f;
 
       f(obj);

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -20,7 +20,7 @@ namespace ed
     {
       return reinterpret_cast<childT>(f);
     }
-    static parentT Convert( parentT f )
+    static parentT Convert( childT f )
     {
       return reinterpret_cast<parentT>(f);
     }

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -1,0 +1,31 @@
+#ifndef _ED_KIT_EVENT_HANDLER_CONVERT_H_
+#define _ED_KIT_EVENT_HANDLER_CONVERT_H_
+
+namespace ed
+{
+  template<typename T>
+  class event_handler_convert;
+
+  template<typename T>
+  class event_handler_convert
+  {
+    typedef void event_context<T> preffered_type;
+    typedef void (*childT)( const preffered & );
+    typedef void (*parentT)( const event_context<> & );
+
+    childT Convert( parentT f )
+    {
+      return reinterpret_cast<childT>(f);
+    }
+  public:
+    virtual void FarCall( parent_T _f, event_context<> &_obj )
+    {
+      preffered_type obj = _obj;
+      childT f = _f;
+
+      f(obj);
+    }
+  };
+};
+
+#endif

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -5,27 +5,27 @@
 
 namespace ed
 {
-  template<typename T>
+  template<typename T, typename RET>
   class event_handler_convert;
 
   class unused_internal_type
   {
   };
 
-  template<>
-  class event_handler_convert<unused_internal_type>
+  template<typename RET>
+  class event_handler_convert<unused_internal_type, RET>
   {
   public:
-    virtual void FarCall( event_context<> &_obj ) = 0;
+    virtual RET FarCall( event_context<> &_obj ) = 0;
   };
 
-  template<typename T>
-  class event_handler_convert : public event_handler_convert<unused_internal_type>
+  template<typename T, typename RET>
+  class event_handler_convert : public event_handler_convert<unused_internal_type, RET>
   {
   public:
     typedef event_context<T> prefferedT;
-    typedef void (*childT)( const prefferedT & );
-    typedef void (*parentT)( const event_context<> & );
+    typedef RET (*childT)( const prefferedT & );
+    typedef RET (*parentT)( const event_context<> & );
 
     static childT Convert( parentT f )
     {
@@ -41,7 +41,7 @@ namespace ed
     event_handler_convert( childT _origin ) : origin(_origin)
     {}
 
-    virtual void FarCall( event_context<> &_obj )
+    virtual RET FarCall( event_context<> &_obj )
     {
       prefferedT obj = _obj;
       childT f = origin;

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -8,8 +8,19 @@ namespace ed
   template<typename T>
   class event_handler_convert;
 
+  class unused_internal_type
+  {
+  };
+
+  template<>
+  class event_handler_convert<unused_internal_type>
+  {
+  public:
+    virtual void FarCall( event_context<> &_obj ) = 0;
+  };
+
   template<typename T>
-  class event_handler_convert
+  class event_handler_convert : public event_handler_convert<unused_internal_type>
   {
   public:
     typedef event_context<T> prefferedT;
@@ -30,7 +41,7 @@ namespace ed
     event_handler_convert( childT _origin ) : origin(_origin)
     {}
 
-    void FarCall( event_context<> &_obj )
+    virtual void FarCall( event_context<> &_obj )
     {
       prefferedT obj = _obj;
       childT f = origin;

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -24,11 +24,16 @@ namespace ed
     {
       return reinterpret_cast<parentT>(f);
     }
+  private:
+    childT origin;
   public:
-    virtual void FarCall( parentT _f, event_context<> &_obj )
+    event_handler_convert( childT _origin ) : origin(_origin)
+    {}
+
+    void FarCall( event_context<> &_obj )
     {
       prefferedT obj = _obj;
-      childT f = _f;
+      childT f = origin;
 
       f(obj);
     }

--- a/source/ed/kit/event_handler_convert.h
+++ b/source/ed/kit/event_handler_convert.h
@@ -40,7 +40,7 @@ namespace ed
       prefferedT obj = _obj;
       childT f = origin;
 
-      (m.*f)(obj);
+      return (m.*f)(obj);
     }
   };
 };

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -14,6 +14,14 @@ module::module( const std::string &name, gateway &_gw )
   gw.CreateModule(name, this);
 }
 
+module::~module()
+{
+  for (unsigned int i = 0; i < QueryCallbacks.size(); ++i)
+    delete QueryCallbacks[i];
+  for (unsigned int i = 0; i < EventCallbacks.size(); ++i)
+    delete EventCallbacks[i];
+}
+
 void module::RegisterEvent( std::string name, int local_id )
 {
   int global_id = gw.RegisterEvent(name);

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -7,6 +7,7 @@
 #include "../notifications/event_types.h"
 #include "../names/reserved.h"
 #include "event_context.h"
+#include "event_handler_convert.h"
 
 namespace ed
 {

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -63,14 +63,17 @@ namespace ed
     }
     void SetPostEventHandler( post_event_handler_t, event_source );
   private:
-    template<typename callback_type>
+    template<typename callback_type, typename RET>
     struct callback_entry
     {
       event_source source;
-      callback_type callback;
+      event_handler_convert<callback_type, RET> callback;
     };
-    std::vector<callback_entry<pre_event_handler_t>> QueryCallbacks;
-    std::vector<callback_entry<post_event_handler_t>> EventCallbacks;
+
+    typedef callback_entry<unused_internal_type, bool> base_pre_callback_entry;
+    typedef callback_entry<unused_internal_type, void> base_post_callback_entry;
+    std::vector<base_pre_callback_entry> QueryCallbacks;
+    std::vector<base_post_callback_entry> EventCallbacks;
 
     void EventReciever( const message & );
     bool Query( const message & );

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -49,26 +49,19 @@ namespace ed
     template<typename T, typename MODULE, typename RET>
     void SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
     {
-      typedef event_handler_convert<T, RET> adapterT;
-      adapterT *test = NEW adapterT(f);
-      callback_entry<unused_internal_type, RET> obj(es, test);
-
-      /*
-      callback_entry<post_event_handler_t> t;
-  t.callback = q;
-  t.source = source;
-  EventCallbacks.push_back(t);
-  gw.Listen(source.instance, id, source.module, adapter.ToGlobal(source.event));       
-  */
+      typedef event_handler_convert<MODULE, T, RET> adapterT;
+      adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);
+      callback_entry<RET> obj(es, test);
+      todo(Add handler);
     }
   private:
-    template<typename callback_type, typename RET>
+    template<typename RET>
     struct callback_entry
     {
       event_source source;
-      event_handler_convert<callback_type, RET> *callback;
+      event_handler_adapter<RET> *callback;
 
-      callback_entry( event_source es, event_handler_convert<callback_type, RET> *t )
+      callback_entry( event_source es, event_handler_adapter<RET> *t )
         : callback(t), source(es)
       {}
       ~callback_entry()
@@ -77,8 +70,8 @@ namespace ed
       }
     };
 
-    typedef callback_entry<unused_internal_type, bool> base_pre_callback_entry;
-    typedef callback_entry<unused_internal_type, void> base_post_callback_entry;
+    typedef callback_entry<bool> base_pre_callback_entry;
+    typedef callback_entry<void> base_post_callback_entry;
     std::vector<base_pre_callback_entry> QueryCallbacks;
     std::vector<base_post_callback_entry> EventCallbacks;
 

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -46,11 +46,21 @@ namespace ed
 
   protected:
 
-    void SetPreEventHandler( pre_event_handler_t, std::string event, 
-      std::string module = "", int source_instance = reserved::instance::BROADCAST );
+    //void SetPreEventHandler( pre_event_handler_t, std::string event, 
+//      std::string module = "", int source_instance = reserved::instance::BROADCAST );
+    template<typename T, typename MODULE>
+    void SetPreEventHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
+    {
+      SetPreEventHandler(reinterpret_cast<pre_event_handler_t>(f), es);
+    }
     void SetPreEventHandler( pre_event_handler_t, event_source );
-    void SetPostEventHandler( post_event_handler_t, std::string event,
-      std::string module = "", int source_instance = reserved::instance::BROADCAST );
+  //  void SetPostEventHandler( post_event_handler_t, std::string event,
+      //std::string module = "", int source_instance = reserved::instance::BROADCAST );
+    template<typename T, typename MODULE>
+    void SetPostEventHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
+    {
+      SetPostEventHandler(reinterpret_cast<post_event_handler_t>(f), es);
+    }
     void SetPostEventHandler( post_event_handler_t, event_source );
   private:
     template<typename callback_type>

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -28,6 +28,7 @@ namespace ed
     std::vector<event_listeners> pre_listeners;
   public:
     module( const std::string &, gateway & );
+    virtual ~module();
     void RegisterEvent( std::string name, int local_id );
     void Listen( int instance, std::string module, std::string event );
     

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -63,7 +63,7 @@ namespace ed
     template<typename T, typename MODULE>
     void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
     {
-      callback_entry<bool> obj = SysCreateHandler<T, MODULE, bool>(f, es);
+      callback_entry<bool> *obj = SysCreateHandler<T, MODULE, bool>(f, es);
       QueryCallbacks.push_back(obj);
     }
 

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -46,28 +46,31 @@ namespace ed
 
   protected:
 
-    //void SetPreEventHandler( pre_event_handler_t, std::string event, 
-//      std::string module = "", int source_instance = reserved::instance::BROADCAST );
-    template<typename T, typename MODULE>
-    void SetPreEventHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
+    template<typename T, typename MODULE, typename RET>
+    void SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
     {
-      SetPreEventHandler(reinterpret_cast<pre_event_handler_t>(f), es);
+      event_handler_convert<> test = f;
+      /*
+      callback_entry<post_event_handler_t> t;
+  t.callback = q;
+  t.source = source;
+  EventCallbacks.push_back(t);
+  gw.Listen(source.instance, id, source.module, adapter.ToGlobal(source.event));       
+  */
     }
-    void SetPreEventHandler( pre_event_handler_t, event_source );
-  //  void SetPostEventHandler( post_event_handler_t, std::string event,
-      //std::string module = "", int source_instance = reserved::instance::BROADCAST );
-    template<typename T, typename MODULE>
-    void SetPostEventHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      SetPostEventHandler(reinterpret_cast<post_event_handler_t>(f), es);
-    }
-    void SetPostEventHandler( post_event_handler_t, event_source );
   private:
     template<typename callback_type, typename RET>
     struct callback_entry
     {
       event_source source;
-      event_handler_convert<callback_type, RET> callback;
+      event_handler_convert<callback_type, RET> *callback;
+
+      callback_entry( event_handler_convert<callback_type, RET> *t ) : callback(t)
+      {}
+      ~callback_entry()
+      {
+        delete callback;
+      }
     };
 
     typedef callback_entry<unused_internal_type, bool> base_pre_callback_entry;

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -49,7 +49,10 @@ namespace ed
     template<typename T, typename MODULE, typename RET>
     void SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
     {
-      event_handler_convert<> test = f;
+      typedef event_handler_convert<T, RET> adapterT;
+      adapterT *test = NEW adapterT(f);
+      callback_entry<unused_internal_type, RET> obj(es, test);
+
       /*
       callback_entry<post_event_handler_t> t;
   t.callback = q;
@@ -65,7 +68,8 @@ namespace ed
       event_source source;
       event_handler_convert<callback_type, RET> *callback;
 
-      callback_entry( event_handler_convert<callback_type, RET> *t ) : callback(t)
+      callback_entry( event_source es, event_handler_convert<callback_type, RET> *t )
+        : callback(t), source(es)
       {}
       ~callback_entry()
       {

--- a/source/ed/kit/module_callback.cpp
+++ b/source/ed/kit/module_callback.cpp
@@ -1,63 +1,21 @@
 #include "module.h"
 
 using namespace ed;
-                /*
-void module::SetPreEventHandler( pre_event_handler_t q, std::string event, std::string module, int source_instance )
-{
-  int module_global_id = gw.RegisterName(MODULES, module);
-  int event_global_id = gw.RegisterName(EVENTS, event);
-
-  event_source es;
-  es.event = event_global_id;
-  es.module = module_global_id;
-  es.instance = source_instance;
-  SetPreEventHandler(q, es);
-}                 */
-
-void module::SetPreEventHandler( pre_event_handler_t q, event_source source )
-{
-  callback_entry<pre_event_handler_t> t;
-  t.callback = q;
-  t.source = source;
-  QueryCallbacks.push_back(t);
-  gw.Listen(source.instance, id, source.module, source.event);
-}
-                   /*
-void module::SetPostEventHandler( post_event_handler_t q, std::string event, std::string module, int source_instance )
-{
-  int module_global_id = gw.RegisterName(MODULES, module);
-  int event_global_id = gw.RegisterName(EVENTS, event);
-
-  event_source es;
-  es.event = event_global_id;
-  es.module = module_global_id;
-  es.instance = source_instance;
-  SetPostEventHandler(q, es);
-}                    */
-
-void module::SetPostEventHandler( post_event_handler_t q, event_source source )
-{
-  callback_entry<post_event_handler_t> t;
-  t.callback = q;
-  t.source = source;
-  EventCallbacks.push_back(t);
-  gw.Listen(source.instance, id, source.module, adapter.ToGlobal(source.event));
-}
-
+            
 
 void module::EventReciever( const message &m )
 {
   const event_source en = static_cast<event_notification>(m);
   event_source en0 = en;
   en0.event = reserved::event::BROADCAST;
-  std::vector<callback_entry<post_event_handler_t>>::const_iterator
+  std::vector<base_post_callback_entry>::const_iterator
     i = EventCallbacks.begin(),
     e = EventCallbacks.end();
   while (i != e)
   {
-    const callback_entry<post_event_handler_t> &t = *i++;
+    const base_post_callback_entry &t = *i++;
     if (en == t.source || en0 == t.source)
-      (this->*t.callback)(
+      t.callback->FarCall(
         event_context<>(
           adapter.ToLocal(m.event),
           en, NEW event_data(m)
@@ -68,14 +26,14 @@ void module::EventReciever( const message &m )
 bool module::Query( const message &m )
 {
   const event_notification en = m;
-  std::vector<callback_entry<pre_event_handler_t>>::const_iterator
+  std::vector<base_pre_callback_entry>::const_iterator
     i = QueryCallbacks.begin(),
     e = QueryCallbacks.end();
   while (i != e)
   {
-    const callback_entry<pre_event_handler_t> &t = *i++;
+    const base_pre_callback_entry &t = *i++;
     if (en.source == t.source)
-      if (!(this->*t.callback)(
+      if (t.callback->FarCall(
           event_context<>(
             adapter.ToLocal(m.event),
             en.source, 

--- a/source/ed/kit/module_callback.cpp
+++ b/source/ed/kit/module_callback.cpp
@@ -1,7 +1,7 @@
 #include "module.h"
 
 using namespace ed;
-
+                /*
 void module::SetPreEventHandler( pre_event_handler_t q, std::string event, std::string module, int source_instance )
 {
   int module_global_id = gw.RegisterName(MODULES, module);
@@ -12,7 +12,7 @@ void module::SetPreEventHandler( pre_event_handler_t q, std::string event, std::
   es.module = module_global_id;
   es.instance = source_instance;
   SetPreEventHandler(q, es);
-}
+}                 */
 
 void module::SetPreEventHandler( pre_event_handler_t q, event_source source )
 {
@@ -22,7 +22,7 @@ void module::SetPreEventHandler( pre_event_handler_t q, event_source source )
   QueryCallbacks.push_back(t);
   gw.Listen(source.instance, id, source.module, source.event);
 }
-
+                   /*
 void module::SetPostEventHandler( post_event_handler_t q, std::string event, std::string module, int source_instance )
 {
   int module_global_id = gw.RegisterName(MODULES, module);
@@ -33,7 +33,7 @@ void module::SetPostEventHandler( post_event_handler_t q, std::string event, std
   es.module = module_global_id;
   es.instance = source_instance;
   SetPostEventHandler(q, es);
-}
+}                    */
 
 void module::SetPostEventHandler( post_event_handler_t q, event_source source )
 {

--- a/source/ed/kit/module_callback.cpp
+++ b/source/ed/kit/module_callback.cpp
@@ -8,12 +8,12 @@ void module::EventReciever( const message &m )
   const event_source en = static_cast<event_notification>(m);
   event_source en0 = en;
   en0.event = reserved::event::BROADCAST;
-  std::vector<base_post_callback_entry>::const_iterator
+  std::vector<base_post_callback_entry *>::const_iterator
     i = EventCallbacks.begin(),
     e = EventCallbacks.end();
   while (i != e)
   {
-    const base_post_callback_entry &t = *i++;
+    const base_post_callback_entry &t = **i++;
     if (en == t.source || en0 == t.source)
       t.callback->FarCall(
         event_context<>(
@@ -26,12 +26,12 @@ void module::EventReciever( const message &m )
 bool module::Query( const message &m )
 {
   const event_notification en = m;
-  std::vector<base_pre_callback_entry>::const_iterator
+  std::vector<base_pre_callback_entry *>::const_iterator
     i = QueryCallbacks.begin(),
     e = QueryCallbacks.end();
   while (i != e)
   {
-    const base_pre_callback_entry &t = *i++;
+    const base_pre_callback_entry &t = **i++;
     if (en.source == t.source)
       if (t.callback->FarCall(
           event_context<>(

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -1,0 +1,42 @@
+#ifndef _ED_KIT_MODULE_IMPL_H_
+#define _ED_KIT_MODULE_IMPL_H_
+
+#include "gateway.h"
+#include "../names/translate.h"
+#include "event_result.h"
+#include "../notifications/event_types.h"
+#include "../names/reserved.h"
+
+namespace ed
+{
+  class module_ed
+  {
+    friend class gateway;
+    friend class event_result;
+    module( int id, gateway & );
+    gateway &gw;
+    int id;
+    translate adapter;
+    bool SendPreEvent( int local_id, message & );
+    void SendPostEvent( int local_id, message & );
+    struct event_listeners
+    {
+      std::list<int> modules;
+    };
+    std::vector<event_listeners> pre_listeners;
+
+    template<typename callback_type>
+    struct callback_entry
+    {
+      event_source source;
+      callback_type callback;
+    };
+    std::vector<callback_entry<query_callback_type>> QueryCallbacks;
+    std::vector<callback_entry<event_callback_type>> EventCallbacks;
+
+    void EventReciever( const message & );
+    bool Query( const message & );
+  };
+};
+
+#endif

--- a/source/server.vcxproj
+++ b/source/server.vcxproj
@@ -37,10 +37,10 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionPath)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\build\$(ProjectName)\$(Configuration)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)\..\intermediate\$(ProjectName)\$(Configuration)\</IntDir>
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
@@ -62,7 +62,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalOptions>$(SolutionPath)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>$(SolutionDir)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)$(SolutionName)_$(ProjectName)_$(Configuration).exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <GenerateMapFile>false</GenerateMapFile>
@@ -91,7 +91,7 @@
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>
     <Link>
-      <AdditionalOptions>$(SolutionPath)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>$(SolutionDir)\..\build\ed\$(Configuration)\ed_$(Configuration).lib %(AdditionalOptions)</AdditionalOptions>
       <OutputFile>$(OutDir)$(SolutionName)_$(ProjectName)_$(Configuration).exe</OutputFile>
       <SubSystem>Console</SubSystem>
       <LargeAddressAware>false</LargeAddressAware>
@@ -105,7 +105,6 @@
   <ItemGroup>
     <ProjectReference Include="ed.vcxproj">
       <Project>{fde0911e-9089-4b5e-a8c4-c55f77d7dc5a}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/source/server.vcxproj
+++ b/source/server.vcxproj
@@ -47,6 +47,8 @@
     <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionName)_$(ProjectName)_$(Configuration)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionName)_$(ProjectName)_$(Configuration)</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
Way recieving event asks incompatible refactored.
Right now you could use your own functions, with your own accepted arguments types, without any static_cast and other.
Anyway code little draft anough, and will be nice, if someone contribute it.

Brief:
Before: only way to register handler for client was:
void my_module::MyFunc( const buffer &incoming_raw_data, event_source es )
{
  my_type t = incoming_raw_data; // parsing
}
....
RegisterEventHandler(static_cast<event_handler_type *>(my_module::*MyFunc), filtered_events);

After:
// type parsed before calling, with throwing `ed_object_translation_failed`.
void my_module::MyFunc( my_type t, event_source es )
{
}
....
RegisterPostHandler(my_module::*MyFunc, filtered_events);
