### PR TITLE
Module code cleanup

### DIFF
--- a/source/client/module_AAA.cpp
+++ b/source/client/module_AAA.cpp
@@ -8,7 +8,7 @@ enum MY_EVENTS
 module_AAA::module_AAA( ed::gateway &_gw ) : module("module_AAA", _gw)
 {
   RegisterEvent(TOSTRING(TEST_EVENT), TEST_EVENT);
-  ed::event_source es;
+  ed::event_source_constructor es = GetSourceConstructor();
   es.event = TEST_EVENT;
   RegisterPostHandler(&module_AAA::AllEventsListener, es);
   RegisterPostHandler(&module_AAA::MyTypeExample, es);

--- a/source/client/module_BBB.cpp
+++ b/source/client/module_BBB.cpp
@@ -11,7 +11,7 @@ module_BBB::module_BBB( ed::gateway &_gw ) : module("moduleBBB", _gw)
   RegisterEvent(TOSTRING(MY_EVENT), MY_EVENT);
   RegisterEvent("TEST_EVENT", AAA_TEST_EVENT);
 
-  ed::event_source es;
+  ed::event_source_constructor es = GetSourceConstructor();
   es.event = AAA_TEST_EVENT;
   RegisterPreHandler(&module_BBB::CheckAAAEventTEST, es);
 }

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -112,7 +112,8 @@
     <ClInclude Include="ed\kit\event_data.h" />
     <ClInclude Include="ed\kit\event_handler_convert.h" />
     <ClInclude Include="ed\kit\gateway_impl.h" />
-    <ClInclude Include="ed\kit\module.hpp" />
+    <ClInclude Include="ed\kit\module_base.hpp" />
+    <ClInclude Include="ed\kit\module_base.h" />
     <ClInclude Include="ed\kit\module_impl.h" />
     <ClInclude Include="ed\names\dictionary.h" />
     <ClInclude Include="ed\names\name_server.h" />
@@ -152,6 +153,7 @@
     <ClCompile Include="ed\exceptions\exception.cpp" />
     <ClCompile Include="ed\kit\event_handler_convert.cpp" />
     <ClCompile Include="ed\kit\gateway_impl.cpp" />
+    <ClCompile Include="ed\kit\module_base.cpp" />
     <ClCompile Include="ed\kit\module_impl.cpp" />
     <ClCompile Include="ed\kit\module_impl_callback.cpp" />
     <ClCompile Include="ed\names\dictionary.cpp" />

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -112,6 +112,7 @@
     <ClInclude Include="ed\kit\event_data.h" />
     <ClInclude Include="ed\kit\event_handler_convert.h" />
     <ClInclude Include="ed\kit\gateway_impl.h" />
+    <ClInclude Include="ed\kit\module.hpp" />
     <ClInclude Include="ed\kit\module_impl.h" />
     <ClInclude Include="ed\names\dictionary.h" />
     <ClInclude Include="ed\names\name_server.h" />

--- a/source/ed.vcxproj
+++ b/source/ed.vcxproj
@@ -111,6 +111,7 @@
     <ClInclude Include="ed\kit\event_context.h" />
     <ClInclude Include="ed\kit\event_data.h" />
     <ClInclude Include="ed\kit\event_handler_convert.h" />
+    <ClInclude Include="ed\kit\event_source_constructor.h" />
     <ClInclude Include="ed\kit\gateway_impl.h" />
     <ClInclude Include="ed\kit\module_base.hpp" />
     <ClInclude Include="ed\kit\module_base.h" />
@@ -152,6 +153,7 @@
     <ClCompile Include="ed\controllers\server_controller_impl.cpp" />
     <ClCompile Include="ed\exceptions\exception.cpp" />
     <ClCompile Include="ed\kit\event_handler_convert.cpp" />
+    <ClCompile Include="ed\kit\event_source_constructor.cpp" />
     <ClCompile Include="ed\kit\gateway_impl.cpp" />
     <ClCompile Include="ed\kit\module_base.cpp" />
     <ClCompile Include="ed\kit\module_impl.cpp" />

--- a/source/ed.vcxproj.filters
+++ b/source/ed.vcxproj.filters
@@ -163,6 +163,9 @@
     <ClInclude Include="ed\kit\module_base.hpp">
       <Filter>kit</Filter>
     </ClInclude>
+    <ClInclude Include="ed\kit\event_source_constructor.h">
+      <Filter>kit</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ed\exceptions\exception.cpp">
@@ -247,6 +250,9 @@
       <Filter>slot\source</Filter>
     </ClCompile>
     <ClCompile Include="ed\kit\module_base.cpp">
+      <Filter>kit</Filter>
+    </ClCompile>
+    <ClCompile Include="ed\kit\event_source_constructor.cpp">
       <Filter>kit</Filter>
     </ClCompile>
   </ItemGroup>

--- a/source/ed.vcxproj.filters
+++ b/source/ed.vcxproj.filters
@@ -157,6 +157,9 @@
     <ClInclude Include="ed\slot\slot.h">
       <Filter>slot</Filter>
     </ClInclude>
+    <ClInclude Include="ed\kit\module.hpp">
+      <Filter>kit</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ed\exceptions\exception.cpp">

--- a/source/ed.vcxproj.filters
+++ b/source/ed.vcxproj.filters
@@ -157,7 +157,10 @@
     <ClInclude Include="ed\slot\slot.h">
       <Filter>slot</Filter>
     </ClInclude>
-    <ClInclude Include="ed\kit\module.hpp">
+    <ClInclude Include="ed\kit\module_base.h">
+      <Filter>kit</Filter>
+    </ClInclude>
+    <ClInclude Include="ed\kit\module_base.hpp">
       <Filter>kit</Filter>
     </ClInclude>
   </ItemGroup>
@@ -242,6 +245,9 @@
     </ClCompile>
     <ClCompile Include="ed\slot\slot_route.cpp">
       <Filter>slot\source</Filter>
+    </ClCompile>
+    <ClCompile Include="ed\kit\module_base.cpp">
+      <Filter>kit</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/source/ed/kit/event_result.cpp
+++ b/source/ed/kit/event_result.cpp
@@ -2,7 +2,7 @@
 
 using namespace ed;
 
-event_result::event_result( message &_e, module &_m, int _local_id, bool _result, EVENT_RING _notify )
+event_result::event_result( message &_e, module_base &_m, int _local_id, bool _result, EVENT_RING _notify )
   : m(_m), local_id(_local_id), result(_result), deactivated(false),
   e(_e), r(_notify)
 {

--- a/source/ed/kit/event_result.h
+++ b/source/ed/kit/event_result.h
@@ -6,12 +6,12 @@
 
 namespace ed
 {
-  class module;
-  class _ED_DLL_EXPORT_ event_result
+  class module_base;
+  class event_result
   {
     mutable bool deactivated;
 
-    module &m;
+    module_base &m;
     message e;
     const int local_id;
     bool result;
@@ -19,7 +19,7 @@ namespace ed
 
     friend class module;
     friend class module_impl;
-    event_result( message &, module &, int local_id, bool result, EVENT_RING notify );
+    event_result( message &, module_base &, int local_id, bool result, EVENT_RING notify );
   public:
     event_result( const event_result & );
 

--- a/source/ed/kit/event_source_constructor.cpp
+++ b/source/ed/kit/event_source_constructor.cpp
@@ -36,3 +36,17 @@ void event_source_constructor::event_source_partial_translator::ByName( const st
 {
   ByGlobal(gw.NameGlobalID(name, nt));
 }
+
+event_source_constructor::event_source_partial_translator &
+  event_source_constructor::event_source_partial_translator::operator=( int local_id )
+{
+  ByLocal(local_id);
+  return *this;
+}
+
+event_source_constructor::event_source_partial_translator &
+  event_source_constructor::event_source_partial_translator::operator=( const std::string &name )
+{
+  ByName(name);
+  return *this;
+}

--- a/source/ed/kit/event_source_constructor.cpp
+++ b/source/ed/kit/event_source_constructor.cpp
@@ -1,0 +1,35 @@
+#include "event_source_constructor.h"
+
+using namespace ed;
+
+event_source_constructor::event_source_constructor()
+ : 
+  instance(es.instance, INSTANCES),
+  module(es.module, MODULES),
+  event(es.event, EVENTS)
+{
+}
+
+event_source_constructor::operator ed::event_source() const
+{
+  return es;
+}
+
+// 
+
+#include "../exceptions/exception.h"
+
+void event_source_constructor::event_source_partial_translator::ByLocal( int id )
+{
+  todo("by local");
+}
+
+void event_source_constructor::event_source_partial_translator::ByGlobal( int id )
+{
+  dep = id;
+}
+
+void event_source_constructor::event_source_partial_translator::ByName( const std::string &name )
+{
+  todo("by name");
+}

--- a/source/ed/kit/event_source_constructor.cpp
+++ b/source/ed/kit/event_source_constructor.cpp
@@ -1,9 +1,9 @@
 #include "event_source_constructor.h"
-#include "gateway.h"
+#include "module.h"
 
 using namespace ed;
 
-event_source_constructor::event_source_constructor( gateway &_gw )
+event_source_constructor::event_source_constructor( module_impl &_gw )
  : 
   gw(_gw),
   instance(_gw, es.instance, INSTANCES),
@@ -33,5 +33,5 @@ void event_source_constructor::event_source_partial_translator::ByGlobal( int id
 
 void event_source_constructor::event_source_partial_translator::ByName( const std::string &name )
 {
-  ByGlobal(gw.RegisterName(nt, name));
+  //ByGlobal(gw.RegisterName(nt, name));
 }

--- a/source/ed/kit/event_source_constructor.cpp
+++ b/source/ed/kit/event_source_constructor.cpp
@@ -1,12 +1,14 @@
 #include "event_source_constructor.h"
+#include "gateway.h"
 
 using namespace ed;
 
-event_source_constructor::event_source_constructor()
+event_source_constructor::event_source_constructor( gateway &_gw )
  : 
-  instance(es.instance, INSTANCES),
-  module(es.module, MODULES),
-  event(es.event, EVENTS)
+  gw(_gw),
+  instance(_gw, es.instance, INSTANCES),
+  module(_gw, es.module, MODULES),
+  event(_gw, es.event, EVENTS)
 {
 }
 
@@ -31,5 +33,5 @@ void event_source_constructor::event_source_partial_translator::ByGlobal( int id
 
 void event_source_constructor::event_source_partial_translator::ByName( const std::string &name )
 {
-  todo("by name");
+  ByGlobal(gw.RegisterName(nt, name));
 }

--- a/source/ed/kit/event_source_constructor.cpp
+++ b/source/ed/kit/event_source_constructor.cpp
@@ -23,7 +23,8 @@ event_source_constructor::operator ed::event_source() const
 
 void event_source_constructor::event_source_partial_translator::ByLocal( int id )
 {
-  todo("by local");
+  const translate &ad = gw.GetAdapter();
+  ByGlobal(ad.ToGlobal(id));
 }
 
 void event_source_constructor::event_source_partial_translator::ByGlobal( int id )
@@ -33,5 +34,5 @@ void event_source_constructor::event_source_partial_translator::ByGlobal( int id
 
 void event_source_constructor::event_source_partial_translator::ByName( const std::string &name )
 {
-  //ByGlobal(gw.RegisterName(nt, name));
+  ByGlobal(gw.NameGlobalID(name, nt));
 }

--- a/source/ed/kit/event_source_constructor.h
+++ b/source/ed/kit/event_source_constructor.h
@@ -8,18 +8,19 @@
 
 namespace ed
 {
+  class module_impl;
   class event_source_constructor
   {
     event_source es;
-    gateway &gw;
+    module_impl &gw;
 
     class event_source_partial_translator
     {
       int &dep;
       NAME_TYPE nt;
-      gateway &gw;
+      module_impl &gw;
     public:
-      event_source_partial_translator( gateway &_gw, int &dependent, NAME_TYPE _nt )
+      event_source_partial_translator( module_impl &_gw, int &dependent, NAME_TYPE _nt )
         : dep(dependent), nt(_nt), gw(_gw)
       {
       }
@@ -31,7 +32,7 @@ namespace ed
     event_source_partial_translator
       instance, module, event;
 
-    event_source_constructor( gateway &gw );
+    event_source_constructor( module_impl &gw );
 
     operator event_source() const;
   };

--- a/source/ed/kit/event_source_constructor.h
+++ b/source/ed/kit/event_source_constructor.h
@@ -1,0 +1,38 @@
+#ifndef _ED_KIT_EVENT_SOURCE_CONSTRUCTOR_H_
+#define _ED_KIT_EVENT_SOURCE_CONSTRUCTOR_H_
+
+#include "../notifications/event_source.h"
+#include "../names/name_type.h"
+
+#include <string>
+
+namespace ed
+{
+  class event_source_constructor
+  {
+    event_source es;
+
+    class event_source_partial_translator
+    {
+      int &dep;
+      NAME_TYPE nt;
+    public:
+      event_source_partial_translator( int &dependent, NAME_TYPE _nt )
+        : dep(dependent), nt(_nt)
+      {
+      }
+      void ByLocal( int id );
+      void ByGlobal( int id );
+      void ByName( const std::string &name );
+    };
+  public:
+    event_source_partial_translator
+      instance, module, event;
+
+    event_source_constructor();
+
+    operator event_source() const;
+  };
+};
+
+#endif

--- a/source/ed/kit/event_source_constructor.h
+++ b/source/ed/kit/event_source_constructor.h
@@ -27,6 +27,9 @@ namespace ed
       void ByLocal( int id );
       void ByGlobal( int id );
       void ByName( const std::string &name );
+
+      event_source_partial_translator &operator=( int local_id );
+      event_source_partial_translator &operator=( const std::string &name );
     };
   public:
     event_source_partial_translator

--- a/source/ed/kit/event_source_constructor.h
+++ b/source/ed/kit/event_source_constructor.h
@@ -11,14 +11,16 @@ namespace ed
   class event_source_constructor
   {
     event_source es;
+    gateway &gw;
 
     class event_source_partial_translator
     {
       int &dep;
       NAME_TYPE nt;
+      gateway &gw;
     public:
-      event_source_partial_translator( int &dependent, NAME_TYPE _nt )
-        : dep(dependent), nt(_nt)
+      event_source_partial_translator( gateway &_gw, int &dependent, NAME_TYPE _nt )
+        : dep(dependent), nt(_nt), gw(_gw)
       {
       }
       void ByLocal( int id );
@@ -29,7 +31,7 @@ namespace ed
     event_source_partial_translator
       instance, module, event;
 
-    event_source_constructor();
+    event_source_constructor( gateway &gw );
 
     operator event_source() const;
   };

--- a/source/ed/kit/gateway.h
+++ b/source/ed/kit/gateway.h
@@ -9,16 +9,18 @@
 
 namespace ed
 {
-  class module;
+  class module_base;
   struct modules_translate : private translate
   {
-    void AddModule( module *local, translate::id_type global )
+    typedef module_base moduleT;
+    void AddModule( moduleT *local, translate::id_type global )
     {
       translate::AddPair(*reinterpret_cast<translate::id_type *>(&local), global);
     }
-    module *GetModule( id_type global ) const
+
+    moduleT *GetModule( id_type global ) const
     {
-      return (module *)ToLocal(global);
+      return (moduleT *)ToLocal(global);
     }
   };
 };

--- a/source/ed/kit/gateway.h
+++ b/source/ed/kit/gateway.h
@@ -36,12 +36,13 @@ namespace ed
 
     friend class gateway_impl;
     friend class module_impl;
-    friend class module;
 
     int RegisterEvent( std::string name );
     bool PreNotify( const message &e );
     void PostNotify( const message &e);
+  public:
     int RegisterName( NAME_TYPE nt, std::string name );
+  private:
     void Listen( int source_instance, int dest_module, std::string module, std::string event );
     void Listen( int source_instance, int dest_module, int module, int event );
 

--- a/source/ed/kit/gateway_impl.cpp
+++ b/source/ed/kit/gateway_impl.cpp
@@ -81,7 +81,7 @@ void gateway_impl::PostNotify( const message &e )
 
 bool gateway_impl::QueryModule( int global_id, const message &e )
 {
-  module *m = local_modules.GetModule(global_id);
+  module_base *m = local_modules.GetModule(global_id);
   return m->Query(e);
 }
 
@@ -119,7 +119,7 @@ void gateway_impl::DelegateNotification( const message &mes, const event_source 
   unsigned int i = 0, s = e.data.size();
   for (i = 0; i < s; ++i)
   {
-    module *m = local_modules.GetModule(e.data[i].module);
+    module_base *m = local_modules.GetModule(e.data[i].module);
     m->EventReciever(mes);
   }
 }

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -51,12 +51,3 @@ void module::Listen( int instance, const std::string &module, const std::string 
 {
   impl.Listen(instance, module, event);
 }
-
-void module::AddPreHandler( base_pre_callback_entry *obj )
-{
-  impl.AddPreHandler(obj);
-}
-void module::AddPostHandler( base_post_callback_entry *obj )
-{
-  impl.AddPostHandler(obj);
-}

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -3,7 +3,7 @@
 
 using namespace ed;
 
-module::module( int _id, gateway &_gw ) : module_base(id, _gw)
+module::module( int _id, gateway &_gw ) : module_base(_id, _gw)
 {
 }
 

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -3,23 +3,16 @@
 
 using namespace ed;
 
-module::module( int _id, gateway &_gw )
-#pragma warning(disable: 4355)
-  : impl(*NEW module_impl(*this, _id, _gw))
-#pragma warning(default: 4355)
+module::module( int _id, gateway &_gw ) : module_base(id, _gw)
 {
 }
 
-module::module( const std::string &name, gateway &_gw )
-#pragma warning(disable: 4355)
-  : impl(*NEW module_impl(*this, name, _gw))
-#pragma warning(default: 4355)
+module::module( const std::string &name, gateway &_gw ) : module_base(name, _gw)
 {
 }
 
 module::~module()
 {
-  delete &impl;
 }
 
 void module::RegisterEvent( const std::string &name, int local_id )

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -51,3 +51,12 @@ void module::Listen( int instance, const std::string &module, const std::string 
 {
   impl.Listen(instance, module, event);
 }
+
+void module::AddPreHandler( module_impl::callback_entry<bool> *obj )
+{
+  impl.AddPreHandler(obj);
+}
+void module::AddPostHandler( module_impl::callback_entry<void> *obj )
+{
+  impl.AddPostHandler(obj);
+}

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -15,11 +15,6 @@ module::~module()
 {
 }
 
-void module::RegisterEvent( const std::string &name, int local_id )
-{
-  impl.RegisterEvent(name, local_id);
-}
-
 event_result module::SendEvent( int local_id, EVENT_RING query_max_ring, EVENT_RING notify_max_ring )
 {
   return impl.SendEvent(local_id, query_max_ring, notify_max_ring);
@@ -28,19 +23,4 @@ event_result module::SendEvent( int local_id, EVENT_RING query_max_ring, EVENT_R
 event_result module::SendEvent( int local_id, buffer payload, EVENT_RING query_max_ring, EVENT_RING notify_max_ring )
 {
   return impl.SendEvent(local_id, payload, query_max_ring, notify_max_ring);
-}
-
-bool module::SendPreEvent( int local_id, message &m )
-{
-  return impl.SendPreEvent(local_id, m);
-}
-
-void module::SendPostEvent( int local_id, message &e )
-{
-  impl.SendPostEvent(local_id, e);
-}
-
-void module::Listen( int instance, const std::string &module, const std::string &event )
-{
-  impl.Listen(instance, module, event);
 }

--- a/source/ed/kit/module.cpp
+++ b/source/ed/kit/module.cpp
@@ -52,11 +52,11 @@ void module::Listen( int instance, const std::string &module, const std::string 
   impl.Listen(instance, module, event);
 }
 
-void module::AddPreHandler( module_impl::callback_entry<bool> *obj )
+void module::AddPreHandler( base_pre_callback_entry *obj )
 {
   impl.AddPreHandler(obj);
 }
-void module::AddPostHandler( module_impl::callback_entry<void> *obj )
+void module::AddPostHandler( base_post_callback_entry *obj )
 {
   impl.AddPostHandler(obj);
 }

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -20,15 +20,7 @@ namespace ed
 
     typedef module_impl::base_pre_callback_entry base_pre_callback_entry;
     typedef module_impl::base_post_callback_entry base_post_callback_entry;
-  private:
 
-    module_impl &impl;
-    friend class gateway;
-    friend class gateway_impl;
-    friend class event_result;
-    module( int id, gateway & );
-    bool SendPreEvent( int local_id, message & );
-    void SendPostEvent( int local_id, message & );
   public:
     module( const std::string &, gateway & );
     virtual ~module();
@@ -44,10 +36,7 @@ namespace ed
       int local_id,
       EVENT_RING query_max_ring = RING0_THREAD,
       EVENT_RING notify_max_ring = RING3_WORLD );
-      
 
-
-  private:
   protected:
     template<typename T, typename MODULE>
     void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
@@ -60,12 +49,22 @@ namespace ed
 
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
+
   private:
     template<typename T, typename MODULE, typename RET>
     module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
 
     void EventReciever( const message & );
     bool Query( const message & );
+
+    friend class gateway;
+    friend class gateway_impl;
+    friend class event_result;
+    module( int id, gateway & );
+    bool SendPreEvent( int local_id, message & );
+    void SendPostEvent( int local_id, message & );
+
+    module_impl &impl;
   };
 };
 

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -3,6 +3,9 @@
 
 #include "module_base.h"
 
+#include "event_result.h"
+#include "../notifications/event_types.h"
+
 namespace ed
 {
   class module : public module_base

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -29,10 +29,6 @@ namespace ed
     module( int id, gateway & );
     bool SendPreEvent( int local_id, message & );
     void SendPostEvent( int local_id, message & );
-    struct event_listeners
-    {
-      std::list<int> modules;
-    };
   public:
     module( const std::string &, gateway & );
     virtual ~module();

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -44,9 +44,6 @@ namespace ed
     template<typename T, typename MODULE>
     void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
 
-    void AddPreHandler( base_pre_callback_entry *obj );
-    void AddPostHandler( base_post_callback_entry *obj );
-
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
 

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -1,31 +1,16 @@
 #ifndef _ED_KIT_MODULE_H_
 #define _ED_KIT_MODULE_H_
 
-#include "gateway.h"
-#include "../names/translate.h"
-#include "event_result.h"
-#include "../notifications/event_types.h"
-#include "../names/reserved.h"
-#include "event_context.h"
-#include "event_handler_convert.h"
+#include "module_base.h"
 
-#include "module_impl.h"
 namespace ed
 {
-  class module
+  class module : public module_base
   {
-  public:
-    typedef bool (module::*pre_event_handler_t)( const event_context<> & );
-    typedef void (module::*post_event_handler_t)( const event_context<> & );
-
-    typedef module_impl::base_pre_callback_entry base_pre_callback_entry;
-    typedef module_impl::base_post_callback_entry base_post_callback_entry;
-
+    module( int id, gateway & );
   public:
     module( const std::string &, gateway & );
     virtual ~module();
-    void RegisterEvent( const std::string &name, int local_id );
-    void Listen( int instance, const std::string &module, const std::string &event );
     
     event_result SendEvent( 
       int local_id,
@@ -36,35 +21,7 @@ namespace ed
       int local_id,
       EVENT_RING query_max_ring = RING0_THREAD,
       EVENT_RING notify_max_ring = RING3_WORLD );
-
-  protected:
-    template<typename T, typename MODULE>
-    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
-
-    template<typename T, typename MODULE>
-    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
-
-    template<typename MODULE>
-    void UnregisterHandlers( const MODULE *const );
-
-  private:
-    template<typename T, typename MODULE, typename RET>
-    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
-
-    void EventReciever( const message & );
-    bool Query( const message & );
-
-    friend class gateway;
-    friend class gateway_impl;
-    friend class event_result;
-    module( int id, gateway & );
-    bool SendPreEvent( int local_id, message & );
-    void SendPostEvent( int local_id, message & );
-
-    module_impl &impl;
   };
 };
-
-#include "module.hpp"
 
 #endif

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -48,18 +48,10 @@ namespace ed
   private:
   protected:
     template<typename T, typename MODULE>
-    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      module_impl::callback_entry<bool> *obj = SysCreateHandler<T, MODULE, bool>(f, es);
-      AddPreHandler(obj);
-    }
+    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
 
     template<typename T, typename MODULE>
-    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      module_impl::callback_entry<void> *obj = SysCreateHandler<T, MODULE, void>(f, es);
-      AddPostHandler(obj);
-    }
+    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
 
     void AddPreHandler( module_impl::callback_entry<bool> *obj )
     {
@@ -71,28 +63,10 @@ namespace ed
     }
 
     template<typename MODULE>
-    void UnregisterHandlers( const MODULE *const )
-    {
-      for (unsigned int i = 0; i < impl.QueryCallbacks.size(); ++i)
-      {
-        delete impl.QueryCallbacks[i];
-        impl.QueryCallbacks[i] = NULL;
-      }
-      for (unsigned int i = 0; i < impl.EventCallbacks.size(); ++i)
-      {
-        delete impl.EventCallbacks[i];
-        impl.EventCallbacks[i] = NULL;
-      }
-    }
-
+    void UnregisterHandlers( const MODULE *const );
   private:
     template<typename T, typename MODULE, typename RET>
-    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      typedef event_handler_convert<MODULE, T, RET> adapterT;
-      adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);
-      return NEW module_impl::callback_entry<RET>(es, test);
-    }
+    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
 
     typedef module_impl::callback_entry<bool> base_pre_callback_entry;
     typedef module_impl::callback_entry<void> base_post_callback_entry;
@@ -103,5 +77,7 @@ namespace ed
     bool Query( const message & );
   };
 };
+
+#include "module.hpp"
 
 #endif

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -14,6 +14,14 @@ namespace ed
 {
   class module
   {
+  public:
+    typedef bool (module::*pre_event_handler_t)( const event_context<> & );
+    typedef void (module::*post_event_handler_t)( const event_context<> & );
+
+    typedef module_impl::base_pre_callback_entry base_pre_callback_entry;
+    typedef module_impl::base_post_callback_entry base_post_callback_entry;
+  private:
+
     module_impl &impl;
     friend class gateway;
     friend class gateway_impl;
@@ -41,8 +49,7 @@ namespace ed
       EVENT_RING query_max_ring = RING0_THREAD,
       EVENT_RING notify_max_ring = RING3_WORLD );
       
-    typedef bool (module::*pre_event_handler_t)( const event_context<> & );
-    typedef void (module::*post_event_handler_t)( const event_context<> & );
+
 
   private:
   protected:
@@ -52,17 +59,14 @@ namespace ed
     template<typename T, typename MODULE>
     void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
 
-    void AddPreHandler( module_impl::callback_entry<bool> *obj );
-    void AddPostHandler( module_impl::callback_entry<void> *obj );
+    void AddPreHandler( base_pre_callback_entry *obj );
+    void AddPostHandler( base_post_callback_entry *obj );
 
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
   private:
     template<typename T, typename MODULE, typename RET>
     module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
-
-    typedef module_impl::callback_entry<bool> base_pre_callback_entry;
-    typedef module_impl::callback_entry<void> base_post_callback_entry;
 
     void EventReciever( const message & );
     bool Query( const message & );

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -12,7 +12,7 @@
 #include "module_impl.h"
 namespace ed
 {
-  class _ED_DLL_EXPORT_ module
+  class module
   {
     module_impl &impl;
     friend class gateway;
@@ -25,7 +25,6 @@ namespace ed
     {
       std::list<int> modules;
     };
-    //std::vector<event_listeners> pre_listeners;
   public:
     module( const std::string &, gateway & );
     virtual ~module();
@@ -64,8 +63,6 @@ namespace ed
 
     typedef module_impl::callback_entry<bool> base_pre_callback_entry;
     typedef module_impl::callback_entry<void> base_post_callback_entry;
-    //std::vector<base_pre_callback_entry *> QueryCallbacks;
-    //std::vector<base_post_callback_entry *> EventCallbacks;
 
     void EventReciever( const message & );
     bool Query( const message & );

--- a/source/ed/kit/module.h
+++ b/source/ed/kit/module.h
@@ -53,14 +53,8 @@ namespace ed
     template<typename T, typename MODULE>
     void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
 
-    void AddPreHandler( module_impl::callback_entry<bool> *obj )
-    {
-      impl.AddPreHandler(obj);
-    }
-    void AddPostHandler( module_impl::callback_entry<void> *obj )
-    {
-      impl.AddPostHandler(obj);
-    }
+    void AddPreHandler( module_impl::callback_entry<bool> *obj );
+    void AddPostHandler( module_impl::callback_entry<void> *obj );
 
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );

--- a/source/ed/kit/module.hpp
+++ b/source/ed/kit/module.hpp
@@ -8,14 +8,14 @@ namespace ed
   void module::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_pre_callback_entry *obj = SysCreateHandler<T, MODULE, bool>(f, es);
-    AddPreHandler(obj);
+    impl.AddPreHandler(obj);
   }
 
   template<typename T, typename MODULE>
   void module::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_post_callback_entry *obj = SysCreateHandler<T, MODULE, void>(f, es);
-    AddPostHandler(obj);
+    impl.AddPostHandler(obj);
   }
 
   template<typename MODULE>

--- a/source/ed/kit/module.hpp
+++ b/source/ed/kit/module.hpp
@@ -1,0 +1,43 @@
+#ifndef _ED_KIT_MODULE_H_
+#error Wrong include order module.hpp before module.h
+#endif
+
+namespace ed
+{
+  template<typename T, typename MODULE>
+  void module::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
+  {
+    module_impl::callback_entry<bool> *obj = SysCreateHandler<T, MODULE, bool>(f, es);
+    AddPreHandler(obj);
+  }
+
+  template<typename T, typename MODULE>
+  void module::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
+  {
+    module_impl::callback_entry<void> *obj = SysCreateHandler<T, MODULE, void>(f, es);
+    AddPostHandler(obj);
+  }
+
+  template<typename MODULE>
+  void module::UnregisterHandlers( const MODULE *const )
+  {
+    for (unsigned int i = 0; i < impl.QueryCallbacks.size(); ++i)
+    {
+      delete impl.QueryCallbacks[i];
+      impl.QueryCallbacks[i] = NULL;
+    }
+    for (unsigned int i = 0; i < impl.EventCallbacks.size(); ++i)
+    {
+      delete impl.EventCallbacks[i];
+      impl.EventCallbacks[i] = NULL;
+    }
+  }
+
+  template<typename T, typename MODULE, typename RET>
+  module_impl::callback_entry<typename RET> *module::SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
+  {
+    typedef event_handler_convert<MODULE, T, RET> adapterT;
+    adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);
+    return NEW module_impl::callback_entry<RET>(es, test);
+  }
+};

--- a/source/ed/kit/module.hpp
+++ b/source/ed/kit/module.hpp
@@ -7,14 +7,14 @@ namespace ed
   template<typename T, typename MODULE>
   void module::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
   {
-    module_impl::callback_entry<bool> *obj = SysCreateHandler<T, MODULE, bool>(f, es);
+    base_pre_callback_entry *obj = SysCreateHandler<T, MODULE, bool>(f, es);
     AddPreHandler(obj);
   }
 
   template<typename T, typename MODULE>
   void module::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
   {
-    module_impl::callback_entry<void> *obj = SysCreateHandler<T, MODULE, void>(f, es);
+    base_post_callback_entry *obj = SysCreateHandler<T, MODULE, void>(f, es);
     AddPostHandler(obj);
   }
 

--- a/source/ed/kit/module_base.cpp
+++ b/source/ed/kit/module_base.cpp
@@ -1,0 +1,32 @@
+#include "module.h"
+
+using namespace ed;
+
+module_base::module_base( int _id, gateway &_gw )
+#pragma warning(disable: 4355)
+  : impl(*NEW module_impl(*this, _id, _gw))
+#pragma warning(default: 4355)
+{
+}
+
+module_base::module_base( const std::string &name, gateway &_gw )
+#pragma warning(disable: 4355)
+  : impl(*NEW module_impl(*this, name, _gw))
+#pragma warning(default: 4355)
+{
+}
+
+module_base::~module_base()
+{
+  delete &impl;
+}
+
+void module_base::EventReciever( const message &m )
+{
+  impl.EventReciever(m);
+}
+
+bool module_base::Query( const message &m )
+{
+  return impl.Query(m); 
+}

--- a/source/ed/kit/module_base.cpp
+++ b/source/ed/kit/module_base.cpp
@@ -50,3 +50,8 @@ void module_base::Listen( int instance, const std::string &module, const std::st
 {
   impl.Listen(instance, module, event);
 }
+
+event_source_constructor module_base::GetSourceConstructor() const
+{
+  return event_source_constructor(impl);
+}

--- a/source/ed/kit/module_base.cpp
+++ b/source/ed/kit/module_base.cpp
@@ -30,3 +30,23 @@ bool module_base::Query( const message &m )
 {
   return impl.Query(m); 
 }
+
+void module_base::RegisterEvent( const std::string &name, int local_id )
+{
+  impl.RegisterEvent(name, local_id);
+}
+
+bool module_base::SendPreEvent( int local_id, message &m )
+{
+  return impl.SendPreEvent(local_id, m);
+}
+
+void module_base::SendPostEvent( int local_id, message &e )
+{
+  impl.SendPostEvent(local_id, e);
+}
+
+void module_base::Listen( int instance, const std::string &module, const std::string &event )
+{
+  impl.Listen(instance, module, event);
+}

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -45,10 +45,9 @@ namespace ed
     module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
 
     void EventReciever( const message & );
-    bool Query( const message & );
+    bool Query( const message & ); // quering module, needed by gateway
     void Listen( int instance, const std::string &module, const std::string &event );
 
-    friend class gateway;
     friend class gateway_impl;
     friend class event_result;
     friend class module;

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -20,8 +20,9 @@ namespace ed
     {
       typedef RET (MODULE::*t)( const event_context<T> & );
     };
-    typedef bool (module_base::*pre_event_handler_t)( const event_context<> & );
-    typedef void (module_base::*post_event_handler_t)( const event_context<> & );
+
+    typedef event_handler<module_base, bool>::t pre_event_handler_t;
+    typedef event_handler<module_base, void>::t post_event_handler_t;
 
     typedef module_impl::base_pre_callback_entry base_pre_callback_entry;
     typedef module_impl::base_post_callback_entry base_post_callback_entry;

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -31,10 +31,10 @@ namespace ed
     ~module_base();
   protected:
     template<typename T, typename MODULE>
-    void RegisterPreHandler( typename event_handler<MODULE, bool, T>::t, event_source es );
+    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
 
     template<typename T, typename MODULE>
-    void RegisterPostHandler( typename event_handler<MODULE, void, T>::t, event_source es );
+    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
 
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
@@ -42,7 +42,7 @@ namespace ed
     void RegisterEvent( const std::string &name, int local_id );
   private:
     template<typename T, typename MODULE, typename RET>
-    module_impl::callback_entry<typename RET> *SysCreateHandler( typename event_handler<MODULE, RET, T>::t, event_source es );
+    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
 
     void EventReciever( const message & );
     bool Query( const message & );

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -1,0 +1,60 @@
+#ifndef _ED_KIT_MODULE_BASE_H_
+#define _ED_KIT_MODULE_BASE_H_
+
+#include "gateway.h"
+#include "../names/translate.h"
+#include "event_result.h"
+#include "../notifications/event_types.h"
+#include "../names/reserved.h"
+#include "event_context.h"
+#include "event_handler_convert.h"
+
+#include "../3party/ax/types.h"
+#include "module_impl.h"
+
+namespace ed
+{
+  class module_base : public ax::object
+  {
+  public:
+    typedef bool (module_base::*pre_event_handler_t)( const event_context<> & );
+    typedef void (module_base::*post_event_handler_t)( const event_context<> & );
+
+    typedef module_impl::base_pre_callback_entry base_pre_callback_entry;
+    typedef module_impl::base_post_callback_entry base_post_callback_entry;
+
+    module_base( const std::string &, gateway & );
+  protected:
+    template<typename T, typename MODULE>
+    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
+
+    template<typename T, typename MODULE>
+    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
+
+    template<typename MODULE>
+    void UnregisterHandlers( const MODULE *const );
+
+  private:
+    template<typename T, typename MODULE, typename RET>
+    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
+
+    void EventReciever( const message & );
+    bool Query( const message & );
+    void RegisterEvent( const std::string &name, int local_id );
+    void Listen( int instance, const std::string &module, const std::string &event );
+
+    friend class gateway;
+    friend class gateway_impl;
+    friend class event_result;
+    module_base( int id, gateway & );
+    bool SendPreEvent( int local_id, message & );
+    void SendPostEvent( int local_id, message & );
+
+    module_impl &impl;
+  };
+};
+
+
+#include "module_base.hpp"
+
+#endif

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -31,10 +31,10 @@ namespace ed
     ~module_base();
   protected:
     template<typename T, typename MODULE>
-    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
+    void RegisterPreHandler( typename event_handler<MODULE, bool, T>::t, event_source es );
 
     template<typename T, typename MODULE>
-    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es );
+    void RegisterPostHandler( typename event_handler<MODULE, void, T>::t, event_source es );
 
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
@@ -42,7 +42,7 @@ namespace ed
     void RegisterEvent( const std::string &name, int local_id );
   private:
     template<typename T, typename MODULE, typename RET>
-    module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
+    module_impl::callback_entry<typename RET> *SysCreateHandler( typename event_handler<MODULE, RET, T>::t, event_source es );
 
     void EventReciever( const message & );
     bool Query( const message & );

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -35,13 +35,13 @@ namespace ed
     template<typename MODULE>
     void UnregisterHandlers( const MODULE *const );
 
+    void RegisterEvent( const std::string &name, int local_id );
   private:
     template<typename T, typename MODULE, typename RET>
     module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );
 
     void EventReciever( const message & );
     bool Query( const message & );
-    void RegisterEvent( const std::string &name, int local_id );
     void Listen( int instance, const std::string &module, const std::string &event );
 
     friend class gateway;

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -3,8 +3,6 @@
 
 #include "gateway.h"
 #include "../names/translate.h"
-#include "event_result.h"
-#include "../notifications/event_types.h"
 #include "../names/reserved.h"
 #include "event_context.h"
 #include "event_handler_convert.h"

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -15,6 +15,11 @@ namespace ed
   class module_base : public ax::object
   {
   public:
+    template<typename MODULE, typename RET, typename T = event_data>
+    struct event_handler
+    {
+      typedef RET (MODULE::*t)( const event_context<T> & );
+    };
     typedef bool (module_base::*pre_event_handler_t)( const event_context<> & );
     typedef void (module_base::*post_event_handler_t)( const event_context<> & );
 

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -9,6 +9,7 @@
 
 #include "../3party/ax/types.h"
 #include "module_impl.h"
+#include "event_source_constructor.h"
 
 namespace ed
 {
@@ -40,6 +41,7 @@ namespace ed
     void UnregisterHandlers( const MODULE *const );
 
     void RegisterEvent( const std::string &name, int local_id );
+    event_source_constructor GetSourceConstructor() const;
   private:
     template<typename T, typename MODULE, typename RET>
     module_impl::callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es );

--- a/source/ed/kit/module_base.h
+++ b/source/ed/kit/module_base.h
@@ -24,6 +24,7 @@ namespace ed
     typedef module_impl::base_post_callback_entry base_post_callback_entry;
 
     module_base( const std::string &, gateway & );
+    ~module_base();
   protected:
     template<typename T, typename MODULE>
     void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es );
@@ -46,6 +47,7 @@ namespace ed
     friend class gateway;
     friend class gateway_impl;
     friend class event_result;
+    friend class module;
     module_base( int id, gateway & );
     bool SendPreEvent( int local_id, message & );
     void SendPostEvent( int local_id, message & );

--- a/source/ed/kit/module_base.hpp
+++ b/source/ed/kit/module_base.hpp
@@ -1,25 +1,25 @@
 #ifndef _ED_KIT_MODULE_H_
-#error Wrong include order module.hpp before module.h
+#error Wrong include order module_base.hpp before module_base.h
 #endif
 
 namespace ed
 {
   template<typename T, typename MODULE>
-  void module::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
+  void module_base::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_pre_callback_entry *obj = SysCreateHandler<T, MODULE, bool>(f, es);
     impl.AddPreHandler(obj);
   }
 
   template<typename T, typename MODULE>
-  void module::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
+  void module_base::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_post_callback_entry *obj = SysCreateHandler<T, MODULE, void>(f, es);
     impl.AddPostHandler(obj);
   }
 
   template<typename MODULE>
-  void module::UnregisterHandlers( const MODULE *const )
+  void module_base::UnregisterHandlers( const MODULE *const )
   {
     for (unsigned int i = 0; i < impl.QueryCallbacks.size(); ++i)
     {
@@ -34,7 +34,7 @@ namespace ed
   }
 
   template<typename T, typename MODULE, typename RET>
-  module_impl::callback_entry<typename RET> *module::SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
+  module_impl::callback_entry<typename RET> *module_base::SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     typedef event_handler_convert<MODULE, T, RET> adapterT;
     adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);

--- a/source/ed/kit/module_base.hpp
+++ b/source/ed/kit/module_base.hpp
@@ -5,14 +5,14 @@
 namespace ed
 {
   template<typename T, typename MODULE>
-  void module_base::RegisterPreHandler( typename event_handler<MODULE, bool, T>::t f, event_source es )
+  void module_base::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_pre_callback_entry *obj = SysCreateHandler<T, MODULE, bool>(f, es);
     impl.AddPreHandler(obj);
   }
 
   template<typename T, typename MODULE>
-  void module_base::RegisterPostHandler( typename event_handler<MODULE, void, T>::t f, event_source es )
+  void module_base::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     base_post_callback_entry *obj = SysCreateHandler<T, MODULE, void>(f, es);
     impl.AddPostHandler(obj);
@@ -34,7 +34,7 @@ namespace ed
   }
 
   template<typename T, typename MODULE, typename RET>
-  module_impl::callback_entry<typename RET> *module_base::SysCreateHandler( typename event_handler<MODULE, RET, T>::t f, event_source es )
+  module_impl::callback_entry<typename RET> *module_base::SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
   {
     typedef event_handler_convert<MODULE, T, RET> adapterT;
     adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);

--- a/source/ed/kit/module_base.hpp
+++ b/source/ed/kit/module_base.hpp
@@ -5,14 +5,14 @@
 namespace ed
 {
   template<typename T, typename MODULE>
-  void module_base::RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
+  void module_base::RegisterPreHandler( typename event_handler<MODULE, bool, T>::t f, event_source es )
   {
     base_pre_callback_entry *obj = SysCreateHandler<T, MODULE, bool>(f, es);
     impl.AddPreHandler(obj);
   }
 
   template<typename T, typename MODULE>
-  void module_base::RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
+  void module_base::RegisterPostHandler( typename event_handler<MODULE, void, T>::t f, event_source es )
   {
     base_post_callback_entry *obj = SysCreateHandler<T, MODULE, void>(f, es);
     impl.AddPostHandler(obj);
@@ -34,7 +34,7 @@ namespace ed
   }
 
   template<typename T, typename MODULE, typename RET>
-  module_impl::callback_entry<typename RET> *module_base::SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
+  module_impl::callback_entry<typename RET> *module_base::SysCreateHandler( typename event_handler<MODULE, RET, T>::t f, event_source es )
   {
     typedef event_handler_convert<MODULE, T, RET> adapterT;
     adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);

--- a/source/ed/kit/module_callback.cpp
+++ b/source/ed/kit/module_callback.cpp
@@ -3,12 +3,3 @@
 using namespace ed;
             
 
-void module::EventReciever( const message &m )
-{
-  impl.EventReciever(m);
-}
-
-bool module::Query( const message &m )
-{
-  return impl.Query(m); 
-}

--- a/source/ed/kit/module_impl.cpp
+++ b/source/ed/kit/module_impl.cpp
@@ -80,12 +80,12 @@ void module_impl::Listen( int instance, const std::string &module, const std::st
   //gw.CreateModule
 }
 
-void module_impl::AddPreHandler( callback_entry<bool> *obj )
+void module_impl::AddPreHandler( base_pre_callback_entry *obj )
 {
   QueryCallbacks.push_back(obj);
   gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));
 }
-void module_impl::AddPostHandler( callback_entry<void> *obj )
+void module_impl::AddPostHandler( base_post_callback_entry *obj )
 {
   EventCallbacks.push_back(obj);
   gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));

--- a/source/ed/kit/module_impl.cpp
+++ b/source/ed/kit/module_impl.cpp
@@ -3,12 +3,12 @@
 
 using namespace ed;
 
-module_impl::module_impl( module &_m, int _id, gateway &_gw )
+module_impl::module_impl( module_base &_m, int _id, gateway &_gw )
   : id(_id), gw(_gw), m(_m)
 {
 }
 
-module_impl::module_impl( module &_m, const std::string &name, gateway &_gw )
+module_impl::module_impl( module_base &_m, const std::string &name, gateway &_gw )
   : gw(_gw), m(_m)
 {
   gw.CreateModule(name, *this);

--- a/source/ed/kit/module_impl.cpp
+++ b/source/ed/kit/module_impl.cpp
@@ -85,8 +85,19 @@ void module_impl::AddPreHandler( base_pre_callback_entry *obj )
   QueryCallbacks.push_back(obj);
   gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));
 }
+
 void module_impl::AddPostHandler( base_post_callback_entry *obj )
 {
   EventCallbacks.push_back(obj);
   gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));
+}
+
+const translate &module_impl::GetAdapter() const
+{
+  return adapter;
+}
+
+int module_impl::NameGlobalID( const std::string &name, NAME_TYPE nt )
+{
+  return gw.RegisterName(nt, name);
 }

--- a/source/ed/kit/module_impl.cpp
+++ b/source/ed/kit/module_impl.cpp
@@ -83,13 +83,13 @@ void module_impl::Listen( int instance, const std::string &module, const std::st
 void module_impl::AddPreHandler( base_pre_callback_entry *obj )
 {
   QueryCallbacks.push_back(obj);
-  gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));
+  gw.Listen(obj->source.instance, id, obj->source.module, obj->source.event);
 }
 
 void module_impl::AddPostHandler( base_post_callback_entry *obj )
 {
   EventCallbacks.push_back(obj);
-  gw.Listen(obj->source.instance, id, obj->source.module, adapter.ToGlobal(obj->source.event));
+  gw.Listen(obj->source.instance, id, obj->source.module, obj->source.event);
 }
 
 const translate &module_impl::GetAdapter() const

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -11,14 +11,16 @@
 
 namespace ed
 {
+  class module_base;
   class module_impl
   {
-    module &m;
+    module_base &m;
     friend class module;
+    friend class module_base;
     friend class gateway;
     friend class gateway_impl;
     friend class event_result;
-    module_impl( module &, int id, gateway & );
+    module_impl( module_base &, int id, gateway & );
     gateway &gw;
     int id;
     translate adapter;
@@ -30,7 +32,7 @@ namespace ed
     };
     std::vector<event_listeners> pre_listeners;
   public:
-    module_impl( module &, const std::string &, gateway & );
+    module_impl( module_base &, const std::string &, gateway & );
     virtual ~module_impl();
     void RegisterEvent( const std::string &name, int local_id );
     void Listen( int instance, const std::string &module, const std::string &event );

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -15,9 +15,7 @@ namespace ed
   class module_impl
   {
     module_base &m;
-    friend class module;
     friend class module_base;
-    friend class gateway;
     friend class gateway_impl;
     friend class event_result;
     module_impl( module_base &, int id, gateway & );
@@ -65,42 +63,11 @@ namespace ed
         delete callback;
       }
     };
+
     typedef callback_entry<bool> base_pre_callback_entry;
     typedef callback_entry<void> base_post_callback_entry;
     void AddPreHandler( base_pre_callback_entry *obj );
     void AddPostHandler( base_post_callback_entry *obj );
-  protected:
-    template<typename T, typename MODULE>
-    void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      callback_entry<bool> *obj = SysCreateHandler<T, MODULE, bool>(f, es);
-      QueryCallbacks.push_back(obj);
-    }
-
-    template<typename T, typename MODULE>
-    void RegisterPostHandler( void (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      callback_entry<void> *obj = SysCreateHandler<T, MODULE, void>(f, es);
-      EventCallbacks.push_back(obj);
-    }
-
-  private:
-    template<typename T, typename MODULE, typename RET>
-    callback_entry<typename RET> *SysCreateHandler( RET (MODULE::*f)( const event_context<T> & ), event_source es )
-    {
-      typedef event_handler_convert<MODULE, T, RET> adapterT;
-      adapterT *test = NEW adapterT(static_cast<MODULE &>(*this), f);
-      return NEW callback_entry<RET>(es, test);
-    }
-
-    template<typename MODULE>
-    void UnregisterHandlers()
-    {
-      for (unsigned int i = 0; i < QueryCallbacks.size(); ++i)
-        delete QueryCallbacks[i];
-      for (unsigned int i = 0; i < EventCallbacks.size(); ++i)
-        delete EventCallbacks[i];
-    }
 
     std::vector<base_pre_callback_entry *> QueryCallbacks;
     std::vector<base_post_callback_entry *> EventCallbacks;

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -34,16 +34,11 @@ namespace ed
     virtual ~module_impl();
     void RegisterEvent( const std::string &name, int local_id );
     void Listen( int instance, const std::string &module, const std::string &event );
+
+
     
-    event_result SendEvent( 
-      int local_id,
-      buffer payload,
-      EVENT_RING query_max_ring = RING0_THREAD,
-      EVENT_RING notify_max_ring = RING3_WORLD );
-    event_result SendEvent( 
-      int local_id,
-      EVENT_RING query_max_ring = RING0_THREAD,
-      EVENT_RING notify_max_ring = RING3_WORLD );
+    event_result SendEvent( int local_id, buffer payload, EVENT_RING query_max_ring, EVENT_RING notify_max_ring);
+    event_result SendEvent( int local_id, EVENT_RING query_max_ring, EVENT_RING notify_max_ring );
       
     typedef bool (module::*pre_event_handler_t)( const event_context<> & );
     typedef void (module::*post_event_handler_t)( const event_context<> & );

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -14,21 +14,6 @@ namespace ed
   class module_base;
   class module_impl
   {
-    module_base &m;
-    friend class module_base;
-    friend class gateway_impl;
-    friend class event_result;
-    module_impl( module_base &, int id, gateway & );
-    gateway &gw;
-    int id;
-    translate adapter;
-    bool SendPreEvent( int local_id, message & );
-    void SendPostEvent( int local_id, message & );
-    struct event_listeners
-    {
-      std::list<int> modules;
-    };
-    std::vector<event_listeners> pre_listeners;
   public:
     module_impl( module_base &, const std::string &, gateway & );
     virtual ~module_impl();
@@ -70,6 +55,22 @@ namespace ed
 
     void EventReciever( const message & );
     bool Query( const message & );
+
+    module_base &m;
+    friend class module_base;
+    friend class gateway_impl;
+    friend class event_result;
+    module_impl( module_base &, int id, gateway & );
+    gateway &gw;
+    int id;
+    translate adapter;
+    bool SendPreEvent( int local_id, message & );
+    void SendPostEvent( int local_id, message & );
+    struct event_listeners
+    {
+      std::list<int> modules;
+    };
+    std::vector<event_listeners> pre_listeners;
   };
 };
 

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -63,8 +63,10 @@ namespace ed
         delete callback;
       }
     };
-    void AddPreHandler( callback_entry<bool> *obj );
-    void AddPostHandler( callback_entry<void> *obj );
+    typedef callback_entry<bool> base_pre_callback_entry;
+    typedef callback_entry<void> base_post_callback_entry;
+    void AddPreHandler( base_pre_callback_entry *obj );
+    void AddPostHandler( base_post_callback_entry *obj );
   protected:
     template<typename T, typename MODULE>
     void RegisterPreHandler( bool (MODULE::*f)( const event_context<T> & ), event_source es )
@@ -98,8 +100,6 @@ namespace ed
         delete EventCallbacks[i];
     }
 
-    typedef callback_entry<bool> base_pre_callback_entry;
-    typedef callback_entry<void> base_post_callback_entry;
     std::vector<base_pre_callback_entry *> QueryCallbacks;
     std::vector<base_post_callback_entry *> EventCallbacks;
 

--- a/source/ed/kit/module_impl.h
+++ b/source/ed/kit/module_impl.h
@@ -35,11 +35,12 @@ namespace ed
     void RegisterEvent( const std::string &name, int local_id );
     void Listen( int instance, const std::string &module, const std::string &event );
 
+    const translate &GetAdapter() const;
+    int NameGlobalID( const std::string &name, NAME_TYPE nt );
 
-    
     event_result SendEvent( int local_id, buffer payload, EVENT_RING query_max_ring, EVENT_RING notify_max_ring);
     event_result SendEvent( int local_id, EVENT_RING query_max_ring, EVENT_RING notify_max_ring );
-      
+
     typedef bool (module::*pre_event_handler_t)( const event_context<> & );
     typedef void (module::*post_event_handler_t)( const event_context<> & );
 

--- a/source/ed/notifications/event_source.h
+++ b/source/ed/notifications/event_source.h
@@ -4,6 +4,7 @@
 #include "../names/reserved.h"
 namespace ed
 {
+  class gateway;
   struct event_source
   {
     int instance, module, event;


### PR DESCRIPTION
Declaration of module more simple right now.
Fixing bug with wrong event_source usage (mix of local and global ids) when registering handler. Now you should use event_source_constructor.
